### PR TITLE
adds rust-fil-proofs version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Uses [shields.io](https://shields.io/) badge service.
 [![User Devnet Release](https://img.shields.io/endpoint.svg?color=brightgreen&style=flat&logo=GitHub&url=https://raw.githubusercontent.com/filecoin-project/go-filecoin-badges/master/user-devnet.json)](https://github.com/filecoin-project/go-filecoin/releases/latest)
 [![Test Devnet Release](https://img.shields.io/endpoint.svg?color=brightgreen&style=flat&logo=GitHub&url=https://raw.githubusercontent.com/filecoin-project/go-filecoin-badges/master/test-devnet.json)](https://github.com/filecoin-project/go-filecoin/releases)
 [![Nightly Devnet Release](https://img.shields.io/endpoint.svg?color=blue&style=flat&logo=GitHub&url=https://raw.githubusercontent.com/filecoin-project/go-filecoin-badges/master/nightly-devnet.json)](https://github.com/filecoin-project/go-filecoin/releases)
+[![Rust-Fil-Proofs Version](https://img.shields.io/endpoint.svg?color=blueviolet&style=flat&logo=GitHub&url=https://raw.githubusercontent.com/filecoin-project/go-filecoin-badges/master/rust-fil-proofs.json)](https://github.com/filecoin-project/rust-fil-proofs)
 
 
 ## License

--- a/rust-file-proofs.json
+++ b/rust-file-proofs.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "rust-fil-proofs version",
+  "message": "d80fae2",
+  "cacheSeconds": 300
+}


### PR DESCRIPTION
show version of rust-fil-proofs currently being used in go-filecoin master.
command used to get version `pushd proofs/rust-fil-proofs > /dev/null && git rev-parse --short HEAD && popd > /dev/null`

Preview:
[![Rust-Fil-Proofs Version](https://img.shields.io/endpoint.svg?color=blueviolet&style=flat&logo=GitHub&url=https://raw.githubusercontent.com/filecoin-project/go-filecoin-badges/5beecde824f7b7a9adeaac4ecdbbdc29bb76ad6a/rust-file-proofs.json)](https://github.com/filecoin-project/rust-fil-proofs)



